### PR TITLE
Hotfix/visibledash

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -71,7 +71,7 @@
                 <button onclick="document.querySelector('#manual-tooltip').onTooltipClose()">Click me to close tooltip!</button>
                 <span class="tooltip">
                     <label>Bottom and no arrow</label>
-                    <core-tooltip placement="bottom" noVisibleArrow>I have no arrow :'(</core-tooltip>
+                    <core-tooltip placement="bottom" no-visible-arrow>I have no arrow :'(</core-tooltip>
                 </span>
             </div>
         </section>

--- a/src/core-tooltip/CoreTooltipElement.css
+++ b/src/core-tooltip/CoreTooltipElement.css
@@ -90,6 +90,6 @@
     transform: translate(-50%, -100%);
 }
 
-:host([noVisibleArrow]) {
+:host([no-visible-arrow]) {
     --arrow-size : 0rem;
 }

--- a/src/core-tooltip/CoreTooltipElement.js
+++ b/src/core-tooltip/CoreTooltipElement.js
@@ -27,6 +27,7 @@ class CoreTooltipElement extends CoreElement {
       for: { type: String },
       focusable: { type: Boolean },
       manual: { type: Boolean },
+      noVisibleArrow: { type: Boolean },
     };
   }
 


### PR DESCRIPTION
Properties, which are specified in "static get properties()" and can be used by "this.PROPNAME", will be parsed into attributes, things that you can specify in html tags, so although they are one-to-one, they are NOT the same. Properties are camelCase, whilst attributes are dash-cased. So this is a fix for noVisibleArrow, which was missing property registration and its attribute name should be "no-visible-arrow".