### PR TITLE
Fix demo to respect dash-case

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -59,8 +59,8 @@
                 </span>
             </div>
             <div>
-                <a>HOVER ME<core-tooltip openDelay="1000" closeDelay="0">TOOLTIPS!</core-tooltip></a>
-                <a>HOVER ME TOO<core-tooltip openDelay="5000">MAOR TOOLTUPS!</core-tooltip></a>
+                <a>HOVER ME<core-tooltip open-delay="1000" close-delay="0">TOOLTIPS!</core-tooltip></a>
+                <a>HOVER ME TOO<core-tooltip open-delay="5000">MAOR TOOLTUPS!</core-tooltip></a>
             </div>
             <div>
                 <span class="tooltip">


### PR DESCRIPTION
Similar to the noVisibleArrow issue, the demo was not using the attribute dash-case. It was using the property camelCase; this case is ONLY used in JavaScript.