### PR TITLE
Change default to respect bootstrap colors

### DIFF
--- a/src/core-slider/CoreSliderElement.css
+++ b/src/core-slider/CoreSliderElement.css
@@ -4,15 +4,15 @@
     
     width: 100%;
     height: auto;
-    color: lightgray;
+    color: var(--light, lightgray);
     
-    --thumb-color: white;
-    --outline-color: gray;
+    --thumb-color: var(--primary, white);
+    --outline-color: var(--secondary, gray);
     --track-color: currentColor;
 }
 
 :host([disabled]) {
-    --thumb-color: gray;
+    --thumb-color: var(--secondary, gray);
     pointer-events: none;
     cursor: default;
 }


### PR DESCRIPTION
Update slider defaults to respect Bootstrap themes (regardless if they actually use it).