### PR TITLE
Add type color for core-link

### DIFF
--- a/src/core-link/CoreLinkElement.css
+++ b/src/core-link/CoreLinkElement.css
@@ -5,3 +5,23 @@
 :host([underline]) a {
   text-decoration: underline;
 }
+
+:host([type=primary]) {
+    color: var(--primary, blue);
+}
+
+:host([type=success]) {
+    color: var(--success, lime);
+}
+
+:host([type=warning]) {
+    color: var(--warning, orange);
+}
+
+:host([type=danger]) {
+    color: var(--danger, tomato);
+}
+
+:host([type=info]) {
+    color: var(--info, slategray);
+}


### PR DESCRIPTION
Allow type to be specified for core-link (also respects Bootstrap colors).